### PR TITLE
Fix: Use relative paths to allow generic mocha execution 1.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.3
+- fix: refactor tests so they can run alongside all other HF/API library tests
+
 # 1.0.2
 - docs: create/update
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # 1.0.3
-- fix: refactor tests so they can run alongside all other HF/API library tests
+- fix: use relative paths to allow generic mocha executio
 
 # 1.0.2
 - docs: create/update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-plugin-wd",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Connection watchdog plugin for the official Bitfinex Node API",
   "engines": {
     "node": ">=7"

--- a/test/self/close.js
+++ b/test/self/close.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const onSelfClose = require('self/close')
+const onSelfClose = require('../../lib/self/close')
 
 describe('self:close', () => {
   const handler = onSelfClose()

--- a/test/self/reconnect.js
+++ b/test/self/reconnect.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const assert = require('assert')
-const WebSocket = require('ws')
-const onSelfReconnect = require('self/reconnect')
 const { EventEmitter } = require('events')
+const WebSocket = require('ws')
+const onSelfReconnect = require('../../lib/self/reconnect')
 
 describe('self:reconnect', () => {
   it('clears timeout and reconnects if socket is closed', (done) => {

--- a/test/ws/close.js
+++ b/test/ws/close.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onWSClose = require('ws/close')
+const onWSClose = require('../../lib/ws/close')
 
 describe('ws:close', () => {
   it('does nothing if autoReconnect is not enabled', () => {

--- a/test/ws/message.js
+++ b/test/ws/message.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isFinite = require('lodash/isFinite')
-const onWSMessage = require('ws/message')
+const onWSMessage = require('../../lib/ws/message')
 
 describe('ws:message', () => {
   it('does nothing if an invalid packet wd delay is specified', () => {

--- a/test/ws/open.js
+++ b/test/ws/open.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onWSOpen = require('ws/open')
+const onWSOpen = require('../../lib/ws/open')
 
 describe('ws:open', () => {
   it('sets managed close flag', () => {


### PR DESCRIPTION
### Fixes:
- [x] Use relative paths to allow generic mocha execution

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
